### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @brynpickering @gincrement


### PR DESCRIPTION
I'm hoping this will be sufficient to avoid security issues with a github bot having the ability to approve pull requests into `main`. The [codeowners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file linked to an update of the branch protection rule should mean that one of us has to approve a PR before it can be merged into `main` (i.e., a bot can't just do it by itself).