### PR TITLE
Add docker image and build config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/**
+!/inventory/output/filtered.csv
+!/inventory/output/stats.csv
+!/inventory/output/docs.csv
+!/user_analysis/output/user_interactions.csv
+!/user_analysis/output/user_classifications.csv
+!/website
+!/.git
+!/README.md
+!/tests/test_app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN pip install --no-cache-dir -r website/requirements.txt pytest --root-user-ac
 
 RUN pytest tests/test_app.py
 
-EXPOSE 8501
+EXPOSE 8080
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-CMD ["streamlit", "run", "website/⚡️_Tool_Repository_Metrics.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "website/⚡️_Tool_Repository_Metrics.py", "--server.port=8080", "--server.address=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13-slim
+
+COPY . ./
+
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir -r website/requirements.txt pytest --root-user-action=ignore
+
+RUN pytest tests/test_app.py
+
+EXPOSE 8501
+
+HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+
+CMD ["streamlit", "run", "website/⚡️_Tool_Repository_Metrics.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/openmod-tracker', '.']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/openmod-tracker']
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      [
+        'run', 'deploy', 'openmod-tracker',
+        '--image', 'gcr.io/$PROJECT_ID/openmod-tracker',
+        '--platform', 'managed',
+        '--allow-unauthenticated'
+      ]
+
+images:
+  - 'gcr.io/$PROJECT_ID/openmod-tracker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,7 @@ steps:
         '--platform', 'managed',
         '--allow-unauthenticated'
       ]
-
+options:
+  logging: CLOUD_LOGGING_ONLY
 images:
   - 'gcr.io/$PROJECT_ID/openmod-tracker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
         'run', 'deploy', 'openmod-tracker',
         '--image', 'gcr.io/$PROJECT_ID/openmod-tracker',
         '--platform', 'managed',
+        '--region', 'europe-west2',
         '--allow-unauthenticated'
       ]
 options:

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Bryn Pickering <17178478+brynpickering@users.noreply.github.com>", "Markus Groissböck <markus.groissbock@openenergytransition.org>"]
 channels = ["conda-forge"]
 name = "open-esm-analysis"
-platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
+platforms = ["win-64", "linux-64", "osx-64", "osx-arm64", "linux-aarch64"]
 version = "0.1.0"
 
 [tasks.get-tools]

--- a/website/pages/1_👤_Deep_Dive:_User_Interaction_Analysis.py
+++ b/website/pages/1_👤_Deep_Dive:_User_Interaction_Analysis.py
@@ -94,7 +94,7 @@ def user_locations_map(
         .to_frame("Number of Users")
         .reset_index(),
         locations="country",
-        locationmode="country names",
+        locationmode="ISO-3",
         color="Number of Users",
         hover_name="country",
         color_continuous_scale=px.colors.sequential.Viridis,


### PR DESCRIPTION
Fixes #77 

There is now a Dockerfile to test and then serve the dashboard plus a cloudbuild config for use by GCP Cloud Build to deploy the dashboard. Result of triggering the GCP Cloud Build on this feature branch can be seen [here](https://openmod-tracker-665022529318.europe-west2.run.app/).