### PR TITLE
Release 2025-08-27; add release guideline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Fixed: for any bug fixes.
 Security: in case of vulnerabilities.
 
 Release headings should be of the form:
-## [X.Y.Z] - YEAR-MONTH-DAY
+## YEAR-MONTH-DAY
 -->
 
 # Changelog
@@ -19,4 +19,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 2025-08-27
+
+Initial release.
+
+### Added
+
+- Open Energy Modelling Tool inventory collector and stats getters.
+- Tool user interaction data collector and user classification.
+- Streamlit web dashboard.
+- Docker image and cloudbuild config to deploy dashboard on Google Cloud Platform.

--- a/README.md
+++ b/README.md
@@ -122,3 +122,22 @@ Further to data from <https://ecosyste.ms>, we rely on other sources to (1) link
    However, they don't store user data unless a user is also a repository owner.
    Direct use of the GitHub API is time intensive due to hourly request limits.
    Therefore, this data (e.g. informing the rate of user interactions over the past 6 months) is updated less frequently than other tools stats.
+
+## Release guideline
+
+We follow calendar versioning (CalVer) in this project.
+To deploy new versions of the dashboard to <https://openmod-tracker.org>, follow these steps:
+
+- Update the changelog with changes since the previous release under a heading with the current date in `YYYY-MM-DD` format.
+- Update the version in the `pixi.toml` to the current date.
+- Open a Pull Request with this change.
+- Once status checks pass and the PR is approved and merged, create a tag locally on the latest commit in the main branch with the same name as the changelog heading, e.g.:
+
+  ```sh
+  git checkout main
+  git pull
+  git tag -a 2025-09-01
+  git push --tag
+  ```
+
+- Create a release in the GitHub web console linked to the tag with the title `Release YYYY-MM-DD` and list the changes since the previous release.

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Bryn Pickering <17178478+brynpickering@users.noreply.github.com>", "
 channels = ["conda-forge"]
 name = "open-esm-analysis"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64", "linux-aarch64"]
-version = "0.1.0"
+version = "2025-08-27"
 
 [tasks.get-tools]
 cmd = "python $PIXI_PROJECT_ROOT/inventory/get_tools.py inventory/output/tools.csv"


### PR DESCRIPTION
Initial release. Commit tags of the form `YYYY-MM-DD` will be required to trigger the dashboard builds from here on.