### PR TITLE
Add core repos for the Energy Transition Model

### DIFF
--- a/inventory/pre_compiled_esm_list.csv
+++ b/inventory/pre_compiled_esm_list.csv
@@ -121,8 +121,6 @@ github.com/powsybl,simulation model
 github.com/psrenergy/SDDPDSO.jl,simulation model
 github.com/PyPSA/PyPSA,
 github.com/quintel/etengine,
-github.com/quintel/etsource,
-github.com/quintel/etmodel,
 github.com/quintel/pyetm,
 github.com/RahmanKhorramfar91/JPoNG,
 github.com/rebase-energy/enflow,simulation model


### PR DESCRIPTION
## Summary of changes in this pull request

- The Energy Transition Model (ETM) consists of three core repositories: etengine, etsource and etmodel. This PR adds the missing repositories etsource and etmodel.
- The ETM API can be communicated with through PyETM, a Python package. This PR adds PyETM.

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

I only made a very small change, so I did not add myself to the AUTHORS.md.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated

I did not make any functional changes, so for now I did not add any tests or update the changelog (as requested in the checklist). If this is necessary, please let me know.