### PR TITLE
Add message_ix to known models

### DIFF
--- a/inventory/pre_compiled_esm_list.csv
+++ b/inventory/pre_compiled_esm_list.csv
@@ -169,3 +169,4 @@ gricad-gitlab.univ-grenoble-alpes.fr/omegalpes/omegalpes,
 jugit.fz-juelich.de/iek-10/public/optimization/comando,
 github.com/ANL-CEEESA/UnitCommitment.jl,production-cost
 github.com/ESMAP-World-Bank-Group/EPM,capacity-expansion
+github.com/iiasa/message_ix,


### PR DESCRIPTION
Fixes #126.

## Summary of changes in this pull request

- Adds message_ix as a known energy systems model :)
- Please let me know if there's anything else you'd like me to do like updating the README or Changelog. So far, I didn't think that was necessary.

## Contributor checklist

- ~[ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).~ Doesn't seem to apply here.
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- ~[ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).~ I can still do that if you want to, but I just added one link.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
