### PR TITLE
Add pre-release and release workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: What version / commit hash of openmod-tracker are you using?
-      placeholder: "2026-03-12"
+      placeholder: "YYYY-MM-DD"
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -24,6 +24,6 @@ body:
     attributes:
       label: Version
       description: What version / commit hash of openmod-tracker are you using?
-      placeholder: "2026-03-12"
+      placeholder: "YYYY-MM-DD"
     validations:
       required: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -70,7 +70,7 @@ jobs:
           BRANCH_NAME="pre-release-${{ steps.version.outputs.date }}"
           git checkout -b $BRANCH_NAME
           git add pixi.toml CHANGELOG.md
-          git commit -m "chore: bump version to ${{ steps.version.outputs.date }}"
+          git diff --staged --quiet || git commit -m "chore: bump version to ${{ steps.version.outputs.date }}"
           git push origin $BRANCH_NAME
           echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: openmod-tracker contributors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Pre-release PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Release date (YYYY-MM-DD). Defaults to today's date."
+        required: false
+        default: ""
+
+jobs:
+  create-prerelease-pr:
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'inventory-update-'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set today's date as version
+        id: version
+        run: |
+          INPUT_DATE="${{ github.event.inputs.date }}"
+          if [[ -n "$INPUT_DATE" ]]; then
+            echo "date=$INPUT_DATE" >> $GITHUB_OUTPUT
+          else
+            echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update pixi.toml version
+        run: |
+          sed -i 's/^version = .*/version = "${{ steps.version.outputs.date }}"/' pixi.toml
+
+      - name: Update CHANGELOG.md Unreleased heading
+        run: |
+          sed -i 's/^## [Uu]nreleased/## ${{ steps.version.outputs.date }}/' CHANGELOG.md
+
+      - name: Generate changelog since last release
+        id: changelog
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [[ -n "$LAST_TAG" ]]; then
+            git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" --no-merges > changelog.txt
+            echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
+          else
+            git log --pretty=format:"- %s" --no-merges > changelog.txt
+            echo "last_tag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Create pre-release branch and commit
+        id: branch
+        run: |
+          BRANCH_NAME="pre-release-${{ steps.version.outputs.date }}"
+          git checkout -b $BRANCH_NAME
+          git add pixi.toml CHANGELOG.md
+          git commit -m "chore: bump version to ${{ steps.version.outputs.date }}"
+          git push origin $BRANCH_NAME
+          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create pre-release PR
+        run: |
+          LAST_TAG="${{ steps.changelog.outputs.last_tag }}"
+          if [[ -n "$LAST_TAG" ]]; then
+            SINCE_TEXT="since \`${LAST_TAG}\`"
+          else
+            SINCE_TEXT="(no previous release found)"
+          fi
+          CHANGELOG=$(cat changelog.txt)
+          {
+            echo "## Pre-release ${{ steps.version.outputs.date }}"
+            echo ""
+            echo "This PR prepares the pre-release for **${{ steps.version.outputs.date }}**, triggered by the merge of the monthly inventory update."
+            echo ""
+            echo "### Changes"
+            echo ""
+            echo "- Bumped \`pixi.toml\` version to \`${{ steps.version.outputs.date }}\`"
+            echo "- Updated \`CHANGELOG.md\` \`Unreleased\` heading to \`${{ steps.version.outputs.date }}\`"
+            echo ""
+            echo "### Changelog ${SINCE_TEXT}"
+            echo ""
+            echo "${CHANGELOG}"
+          } > pr_body.md
+          gh pr create \
+            --title "chore: pre-release ${{ steps.version.outputs.date }}" \
+            --body-file pr_body.md \
+            --base main \
+            --head "${{ steps.branch.outputs.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: openmod-tracker contributors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Tagged Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version / tag (YYYY-MM-DD)"
+        required: true
+
+jobs:
+  prepare:
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'pre-release-'))
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Extract version from branch name
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            VERSION="${BRANCH#pre-release-}"
+            echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
+  create-release:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag "${{ needs.prepare.outputs.tag }}"
+          git push origin "${{ needs.prepare.outputs.tag }}"
+
+      - name: Create GitHub release
+        run: |
+          gh release create "${{ needs.prepare.outputs.tag }}" \
+            --title "Release ${{ needs.prepare.outputs.tag }}" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Calendar Versioning](https://calver.org/).
 
+## Unreleased
+
+### Added
+
+- Active maintainer number (#182).
+- Repo dependabot, code quality, and secret scanning in `openmod-tracker` source code repo.
+- Automated release process following monthly inventory auto-update.
+
+## Changed
+
+- Tulipa energy & antares_simulator categories updated
+
 ## 2026-03-12
 
 ### Added
 
 - Repo interaction and user detail cleaning when removing a repo with existing downloaded data.
 - Warning on category assignments referring to IDs not defined in the tool list.
-- Active maintainer number.
 
 ### Fixed
 


### PR DESCRIPTION
Hands off the release process to github actions so that if everything works as intended, we are requested as reviewers when the monthly release cycle is due.

As with any github workflow, it's next to impossible to test this locally so I won't know for sure that it works until it's all triggered (due in a few days time).

## Summary of changes in this pull request

- pre-release workflow that updates versions in a few files once the monthly inventory auto-update has been successfully merged into `main`
- release workflow that tags the latest on `main` with the release date and then creates a release (after maintainer approval). This in turn will trigger a GCP workflow that creates a new openmod-tracker.org release
- Updated the changelog as we didn't yet have a section for the changes since our last release.

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
