### PR TITLE
Add Cairn Open to the inventory

### DIFF
--- a/inventory/pre_compiled_esm_list.csv
+++ b/inventory/pre_compiled_esm_list.csv
@@ -27,6 +27,7 @@ github.com/Breakthrough-Energy/REISE.jl,
 github.com/BTU-EnerEcon/EM.POWER-INVEST,
 github.com/caaficus/BeWhere-model,
 github.com/calliope-project/calliope,
+github.com/CEA-Liten/CairnOpen,
 github.com/changgang/steps,simulation model
 github.com/chengts95/rustpower,simulation model
 github.com/Critical-Infrastructure-Systems-Lab/PowNet,


### PR DESCRIPTION
Add Cairn open to the list. https://github.com/CEA-Liten/CairnOpen.

Resolves this issue: 

https://github.com/open-energy-transition/openmod-tracker/issues/227 

CairnOpen was also added to OET. 