### PR TITLE
Add hydesign simulation model to pre_compiled_esm_list

### DIFF
--- a/inventory/pre_compiled_esm_list.csv
+++ b/inventory/pre_compiled_esm_list.csv
@@ -175,4 +175,4 @@ github.com/QuaSi-Software/resie,simulation model
 github.com/ESDLMapEditorESSIM/essim,simulation model
 github.com/powergama/powergama
 github.com/tum-ens/HAMLET
-github.com/DTUWindEnergy/hydesign,simulation model
+gitlab.windenergy.dtu.dk/TOPFARM/hydesign.git,simulation model

--- a/inventory/pre_compiled_esm_list.csv
+++ b/inventory/pre_compiled_esm_list.csv
@@ -175,3 +175,4 @@ github.com/QuaSi-Software/resie,simulation model
 github.com/ESDLMapEditorESSIM/essim,simulation model
 github.com/powergama/powergama
 github.com/tum-ens/HAMLET
+github.com/DTUWindEnergy/hydesign,simulation model


### PR DESCRIPTION
HyDesign is the DTU tool for design, control and optimization of utility scale Hybrid Power- and Energy Plants including wind, solar, storage and P2X technologies.

Hydesign is a non-linear model for evaluating HPP projects including:

Wind turbine selection
Wake losses that depend on the number of turbines and the installation density of the wind plant Internal energy management system operation of the plant. The operation of the HPP plant is designed in an ideal scenario without degradation and an actual operation that can include degradation of the battery, or PV plant, as well as forecast errors in wind, solar and spot prices. Non-linear battery degradation
Detailed cost models for wind, solar and Li-ion battery Detailed financial model based on weighted costs of capital per technology P2X capability with power to Hydrogen

Fixes #

## Summary of changes in this pull request

-
-
-

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
