### PR TITLE
Use tool and stats CSVs as fallbacks more often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Calendar Versioning](https://calver.org/).
 
+## Unreleased
+
+### Fixed
+
+* Rely on existing tool CSV as a fallback of all tools, in case one of the upstream inventories becomes unavailable.
+* Extend use of existing tools stats as fallback on all non-404 response codes when querying ecosyste-ms API (previously only 500 status code).
+
 ## 2026-05-28
 
 ### Added

--- a/inventory/get_tools.py
+++ b/inventory/get_tools.py
@@ -283,7 +283,9 @@ def cli(outfile: Path):
     entries = add_categories(entries)
     if outfile.exists():
         existing = pd.read_csv(outfile)
-        entries = pd.concat([existing, entries], ignore_index=True).drop_duplicates()
+        entries = pd.concat([existing, entries], ignore_index=True).drop_duplicates(
+            ["source", "name", "url"], keep="last"
+        )
 
     entries.sort_values(["id", "category"]).to_csv(outfile, index=False)
 

--- a/inventory/get_tools.py
+++ b/inventory/get_tools.py
@@ -281,6 +281,9 @@ def cli(outfile: Path):
     )
 
     entries = add_categories(entries)
+    if outfile.exists():
+        existing = pd.read_csv(outfile)
+        entries = pd.concat([existing, entries], ignore_index=True).drop_duplicates()
 
     entries.sort_values(["id", "category"]).to_csv(outfile, index=False)
 

--- a/inventory/util.py
+++ b/inventory/util.py
@@ -54,7 +54,7 @@ def get_ecosystems_data(url: str) -> list[dict] | dict | str | None:
 
     if response.ok:
         return yaml.safe_load(response.content.decode("utf-8"))
-    elif response.status_code != 500:
+    elif response.status_code == 404:
         LOGGER.warning(f"Static URL {url} returned {response.status_code} status code.")
         return "not-found"
     else:


### PR DESCRIPTION
It doesn't fix the underlying opensustain.tech issue we're having (#248) that led to tools being lost in #247 but it circumvents the issue when it arises by using existing CSVs as a fallback.

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
